### PR TITLE
Wifi monitor

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,8 +4,6 @@
 
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-<!--    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />-->
-<!--    <uses-permission android:name="android.permission.INTERNET" />-->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,10 @@
 
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+<!--    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />-->
+<!--    <uses-permission android:name="android.permission.INTERNET" />-->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/example/mobile/MainActivity.kt
+++ b/app/src/main/java/com/example/mobile/MainActivity.kt
@@ -102,8 +102,6 @@ class MainActivity : ComponentActivity() {
                 Manifest.permission.RECORD_AUDIO,
                 Manifest.permission.ACCESS_WIFI_STATE,
                 Manifest.permission.ACCESS_FINE_LOCATION,
-                Manifest.permission.ACCESS_COARSE_LOCATION
-
             ),
             0
         )
@@ -112,10 +110,26 @@ class MainActivity : ComponentActivity() {
 
     //test monitoring for AudioMonitor
     private fun startAudioMonitoring() {
-        audioMonitoringJob = CoroutineScope(Dispatchers.IO).launch {
-            while(true) {
-                value = audioMonitor.readValue()
-                delay(AudioMonitor.defaultTimePeriodMs)
+        if (ActivityCompat.checkSelfPermission(
+                this,
+                Manifest.permission.RECORD_AUDIO
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            // TODO: Consider calling
+            //    ActivityCompat#requestPermissions
+            // here to request the missing permissions, and then overriding
+            //   public void onRequestPermissionsResult(int requestCode, String[] permissions,
+            //                                          int[] grantResults)
+            // to handle the case where the user grants the permission. See the documentation
+            // for ActivityCompat#requestPermissions for more details.
+            return
+        }
+        audioMonitor.startMonitoring {
+            audioMonitoringJob = CoroutineScope(Dispatchers.IO).launch {
+                while(true) {
+                    value = audioMonitor.readValue()
+                    delay(AudioMonitor.defaultTimePeriodMs)
+                }
             }
         }
     }
@@ -126,6 +140,14 @@ class MainActivity : ComponentActivity() {
 
     //test monitoring for WifiMonitor
     private fun startWifiMonitoring() {
+        if (ActivityCompat.checkSelfPermission(
+                this,
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            requestPermissions()
+            return
+        }
         wifiMonitor.startMonitoring {
             wifiMonitoringJob = CoroutineScope(Dispatchers.IO).launch {
                 while(true) {

--- a/app/src/main/java/com/example/mobile/monitors/AudioMonitor.kt
+++ b/app/src/main/java/com/example/mobile/monitors/AudioMonitor.kt
@@ -23,7 +23,7 @@ class AudioMonitor(): IMonitor {
     }
 
     @RequiresPermission(value = "android.permission.RECORD_AUDIO")
-    override fun startMonitoring() {
+    override fun startMonitoring(onStart: () -> Unit) {
         audioRecorder = AudioRecord(
             MediaRecorder.AudioSource.MIC,
             sampleFrequency,
@@ -32,6 +32,7 @@ class AudioMonitor(): IMonitor {
             bufferSize
         )
         audioRecorder?.startRecording()
+        onStart()
     }
 
     override fun stopMonitoring() {

--- a/app/src/main/java/com/example/mobile/monitors/IMonitor.kt
+++ b/app/src/main/java/com/example/mobile/monitors/IMonitor.kt
@@ -2,7 +2,7 @@ package com.example.mobile.monitors
 
 interface IMonitor {
     //TODO: maybe also add pause/resume functionality   
-    fun startMonitoring()
+    fun startMonitoring(onStart: () -> Unit)
     fun stopMonitoring()
     fun readValue(): Double
 }

--- a/app/src/main/java/com/example/mobile/monitors/WifiMonitor.kt
+++ b/app/src/main/java/com/example/mobile/monitors/WifiMonitor.kt
@@ -1,0 +1,62 @@
+package com.example.mobile.monitors
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.wifi.ScanResult
+import android.net.wifi.WifiManager
+import android.util.Log
+import androidx.core.app.ActivityCompat
+
+class WifiMonitor(
+    // importante che sia proprio l'applicationContext e non un Context derivato per release <=
+    // Build.VERSION_CODES.N, tanto vale usare sempre questo di default se non ci causa problemi
+    // reference: https://developer.android.com/reference/android/net/wifi/WifiManager
+    applicationContext: Context
+): IMonitor {
+    private val applicationContext: Context = applicationContext
+    private val wifiManager: WifiManager = applicationContext.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+
+    companion object {
+        // periodo di esecuzione delle misurazioni suggerito
+        const val defaultTimePeriodMs: Long = 1000
+    }
+
+    override fun startMonitoring() {
+
+    }
+
+    override fun stopMonitoring() {
+
+    }
+
+    override fun readValue(): Double {
+        if (ActivityCompat.checkSelfPermission(
+                this.applicationContext,
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            // TODO: Consider calling
+            //    ActivityCompat#requestPermissions
+            // here to request the missing permissions, and then overriding
+            //   public void onRequestPermissionsResult(int requestCode, String[] permissions,
+            //                                          int[] grantResults)
+            // to handle the case where the user grants the permission. See the documentation
+            // for ActivityCompat#requestPermissions for more details.
+            return 0.0
+        }
+
+        val scanResults: List<ScanResult> = wifiManager.scanResults
+        if (scanResults.isEmpty()) {
+            Log.d("miotag", "SCAN RESULT VUOTO")
+            return 0.0
+        }
+        else {
+            Log.d("miotag", "SCAN CON ${scanResults.size} RISULTATI")
+            // Calculate average signal strength in dBm
+            val totalSignalStrength = scanResults.sumBy { it.level }
+            val averageSignalStrength = totalSignalStrength.toDouble() / scanResults.size
+            return averageSignalStrength
+        }
+    }
+}

--- a/app/src/main/java/com/example/mobile/monitors/WifiMonitor.kt
+++ b/app/src/main/java/com/example/mobile/monitors/WifiMonitor.kt
@@ -11,6 +11,7 @@ import android.net.wifi.ScanResult
 import android.net.wifi.WifiManager
 import android.provider.Settings
 import android.util.Log
+import androidx.annotation.RequiresPermission
 import androidx.core.app.ActivityCompat
 
 class WifiMonitor(
@@ -67,6 +68,7 @@ class WifiMonitor(
 //        dialog.show()
     }
 
+    @RequiresPermission(value = "android.permission.ACCESS_FINE_LOCATION")
     fun startMonitoring(onStart: () -> Unit) {
         //TODO: add strings resources to avoid these hard coded strings
         if (!isWifiEnabled()) {

--- a/app/src/main/java/com/example/mobile/monitors/WifiMonitor.kt
+++ b/app/src/main/java/com/example/mobile/monitors/WifiMonitor.kt
@@ -1,36 +1,103 @@
 package com.example.mobile.monitors
 
 import android.Manifest
+import android.app.Activity
+import android.app.AlertDialog
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
+import android.location.LocationManager
 import android.net.wifi.ScanResult
 import android.net.wifi.WifiManager
+import android.provider.Settings
 import android.util.Log
 import androidx.core.app.ActivityCompat
 
 class WifiMonitor(
+    activity: Activity,
     // importante che sia proprio l'applicationContext e non un Context derivato per release <=
     // Build.VERSION_CODES.N, tanto vale usare sempre questo di default se non ci causa problemi
     // reference: https://developer.android.com/reference/android/net/wifi/WifiManager
     applicationContext: Context
-): IMonitor {
-    private val applicationContext: Context = applicationContext
-    private val wifiManager: WifiManager = applicationContext.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+) {
+    private val applicationContext = applicationContext
+    private val activity = activity
+    private val wifiManager = applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+    private val locationManager = applicationContext.getSystemService(Context.LOCATION_SERVICE) as LocationManager
 
     companion object {
         // periodo di esecuzione delle misurazioni suggerito
-        const val defaultTimePeriodMs: Long = 1000
+        const val defaultTimePeriodMs: Long = 60000
     }
 
-    override fun startMonitoring() {
+    fun isWifiEnabled(): Boolean {
+        return wifiManager.isWifiEnabled
+    }
+
+    fun isLocationEnabled(): Boolean {
+        return locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)
+    }
+
+    private fun requestSettingEnabled(title: String, message: String, intent: Intent) {
+        //TODO: check if a custom UI dialog would be better (example at the end of the function body)
+        val builder = AlertDialog.Builder(activity)
+
+        builder.setTitle(title)
+        builder.setMessage(message)
+        builder.setPositiveButton("Ok") { dialog, _ ->
+            activity.startActivity(intent)
+            dialog.dismiss()
+        }
+        builder.setNegativeButton("Cancel") { dialog, _ ->
+            dialog.dismiss()
+        }
+
+        val dialog = builder.create()
+        dialog.show()
+
+//        val dialog = Dialog(this)
+//        dialog.setContentView(R.layout.custom_dialog_layout)
+//        dialog.setContent(ComposableContent(?))
+//        val enableButton = dialog.findViewById<Button>(R.id.enableButton)
+//        enableButton.setOnClickListener {
+//            val wifiIntent = Intent(Settings.ACTION_WIFI_SETTINGS)
+//            startActivity(wifiIntent)
+//            dialog.dismiss()
+//        }
+//        dialog.show()
+    }
+
+    fun startMonitoring(onStart: () -> Unit) {
+        //TODO: add strings resources to avoid these hard coded strings
+        if (!isWifiEnabled()) {
+            val wifiIntent = Intent(Settings.ACTION_WIFI_SETTINGS)
+            requestSettingEnabled(
+                "Enable Wifi connection",
+                "In order to monitor the strength of wifi connections in your area you need to turn wifi connectivity",
+                wifiIntent
+            )
+        } else if (!isLocationEnabled()) {
+            val locationIntent = Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
+            requestSettingEnabled(
+                "Enable location",
+                "In order to monitor the strength of wifi connections android also requires to turn on the location.\n" +
+                        "This is because if you monitor the available wifi connection you could get a good approximation of where " +
+                        "the device is located. This does not mean that the application will check the device's location.",
+                locationIntent
+            )
+        }
+        if (isWifiEnabled() && isLocationEnabled()) {
+            onStart()
+        }
+    }
+
+    fun stopMonitoring() {
 
     }
 
-    override fun stopMonitoring() {
-
-    }
-
-    override fun readValue(): Double {
+    // value read in dBm
+    fun readValue(): Double {
+        //TODO: properly manage permissions
         if (ActivityCompat.checkSelfPermission(
                 this.applicationContext,
                 Manifest.permission.ACCESS_FINE_LOCATION
@@ -46,6 +113,8 @@ class WifiMonitor(
             return 0.0
         }
 
+        //TODO: implement signal monitoring for both any network and only the connected one
+        //TODO: get rid of logging
         val scanResults: List<ScanResult> = wifiManager.scanResults
         if (scanResults.isEmpty()) {
             Log.d("miotag", "SCAN RESULT VUOTO")


### PR DESCRIPTION
Aggiunto il WifiMonitor, classe che implementa l'interfaccia IMonitor e il monitoring dell'intensità di tutte le reti disponibili, calcolandone la media, in dBm.
Anche l'interfaccia IMonitor è stata aggiornata per includere una callback come argomento di startMonitoring, eseguita quando il monitor è pronto per essere utilizzato, nel caso il chiamata debba eseguire del codice extra quando il monitor è pronto per chiamare readValue